### PR TITLE
Refactor ZIP extraction logic based on volume file existence

### DIFF
--- a/Tutorials/STC-SEG-103_AIBasedSegmentationIn3DSlicer/AIBasedSegmentationIn3DSlicer.py
+++ b/Tutorials/STC-SEG-103_AIBasedSegmentationIn3DSlicer/AIBasedSegmentationIn3DSlicer.py
@@ -105,15 +105,17 @@ class Slicer4MinuteTest(ScriptedLoadableModuleTest):
         if not os.path.exists(zip_path):
             urllib.request.urlretrieve(zip_url, zip_path)
 
-        # Extrair ZIP se não estiver extraído
-        if not os.path.exists(extract_path):
-            with zipfile.ZipFile(zip_path, 'r') as zip_ref:
-                zip_ref.extractall(slicer.app.temporaryPath)
-
         # Carregar os volumes
         prostate_folder = os.path.join(extract_path, "dataset3_ProstateMRI")
         adc_path = os.path.join(prostate_folder, "msd-prostate-01-adc.nrrd")
         t2_path = os.path.join(prostate_folder, "msd-prostate-01-t2.nrrd")
+
+        # Extrair ZIP se não estiver extraído
+        if not (os.path.exists(adc_path) and os.path.exists(t2_path)):
+            with zipfile.ZipFile(zip_path, 'r') as zip_ref:
+                zip_ref.extractall(slicer.app.temporaryPath)
+
+        
 
         slicer.util.loadVolume(adc_path)
         slicer.util.loadVolume(t2_path)


### PR DESCRIPTION
After working with @MonseRiosH , we realized there was a problem with the logic for extracting the Prostate image zip file.

With the proposed modifications, we corrected the above and resolved the issue described in [](https://github.com/SoniaPujolLab/SlicerTutorialMaker/issues/125)

How was it resolved?
The ZIP extraction logic was moved to check for specific volume files before extraction.